### PR TITLE
Issue #17 - breaking changes on `master`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,18 +17,18 @@ codec = {default-features = false, features = ['derive','max-encoded-len'], pack
 scale-info = {default-features = false, features = ['derive'], version = '1.0'}
 
 # primitives
-sp-std = {default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = '3dc984280b4380179fa83a3895aff84048dfe146'}
+sp-std = {default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = '55cd07a7e22c26932f7bd16b87ea5a7569e38eb4'}
 
 # Substrate dependencies
-frame-benchmarking = {default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = '3dc984280b4380179fa83a3895aff84048dfe146', optional = true}
-frame-support = {default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = '3dc984280b4380179fa83a3895aff84048dfe146'}
-frame-system = {default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = '3dc984280b4380179fa83a3895aff84048dfe146'}
+frame-benchmarking = {default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = '55cd07a7e22c26932f7bd16b87ea5a7569e38eb4', optional = true}
+frame-support = {default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = '55cd07a7e22c26932f7bd16b87ea5a7569e38eb4'}
+frame-system = {default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = '55cd07a7e22c26932f7bd16b87ea5a7569e38eb4'}
 
 [dev-dependencies]
 serde = '1.0.126'
-sp-runtime = {default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = '3dc984280b4380179fa83a3895aff84048dfe146'}
-sp-core = {default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = '3dc984280b4380179fa83a3895aff84048dfe146'}
-sp-io = {default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = '3dc984280b4380179fa83a3895aff84048dfe146'}
+sp-runtime = {default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = '55cd07a7e22c26932f7bd16b87ea5a7569e38eb4'}
+sp-core = {default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = '55cd07a7e22c26932f7bd16b87ea5a7569e38eb4'}
+sp-io = {default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = '55cd07a7e22c26932f7bd16b87ea5a7569e38eb4'}
 
 [features]
 default = ['std']

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,18 +17,18 @@ codec = {default-features = false, features = ['derive','max-encoded-len'], pack
 scale-info = {default-features = false, features = ['derive'], version = '1.0'}
 
 # primitives
-sp-std = {default-features = false, version = '4.0.0-dev', git = 'https://github.com/paritytech/substrate.git', branch = 'master'}
+sp-std = {default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = '3dc984280b4380179fa83a3895aff84048dfe146'}
 
 # Substrate dependencies
-frame-benchmarking = {default-features = false, optional = true, version = '4.0.0-dev', git = 'https://github.com/paritytech/substrate.git', branch = 'master'}
-frame-support = {default-features = false, version = '4.0.0-dev', git = 'https://github.com/paritytech/substrate.git', branch = 'master'}
-frame-system = {default-features = false, version = '4.0.0-dev', git = 'https://github.com/paritytech/substrate.git', branch = 'master'}
+frame-benchmarking = {default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = '3dc984280b4380179fa83a3895aff84048dfe146', optional = true}
+frame-support = {default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = '3dc984280b4380179fa83a3895aff84048dfe146'}
+frame-system = {default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = '3dc984280b4380179fa83a3895aff84048dfe146'}
 
 [dev-dependencies]
 serde = '1.0.126'
-sp-runtime = {default-features = false, version = '4.0.0-dev', git = 'https://github.com/paritytech/substrate.git', branch = 'master'}
-sp-core = {default-features = false, version = '4.0.0-dev', git = 'https://github.com/paritytech/substrate.git', branch = 'master'}
-sp-io = {default-features = false, version = '4.0.0-dev', git = 'https://github.com/paritytech/substrate.git', branch = 'master'}
+sp-runtime = {default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = '3dc984280b4380179fa83a3895aff84048dfe146'}
+sp-core = {default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = '3dc984280b4380179fa83a3895aff84048dfe146'}
+sp-io = {default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = '3dc984280b4380179fa83a3895aff84048dfe146'}
 
 [features]
 default = ['std']

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,18 +17,18 @@ codec = {default-features = false, features = ['derive','max-encoded-len'], pack
 scale-info = {default-features = false, features = ['derive'], version = '1.0'}
 
 # primitives
-sp-std = {default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = '55cd07a7e22c26932f7bd16b87ea5a7569e38eb4'}
+sp-std = {default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = '2a7a734c373d0b28c6c658667effd3fb8c9e35bf'}
 
 # Substrate dependencies
-frame-benchmarking = {default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = '55cd07a7e22c26932f7bd16b87ea5a7569e38eb4', optional = true}
-frame-support = {default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = '55cd07a7e22c26932f7bd16b87ea5a7569e38eb4'}
-frame-system = {default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = '55cd07a7e22c26932f7bd16b87ea5a7569e38eb4'}
+frame-benchmarking = {default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = '2a7a734c373d0b28c6c658667effd3fb8c9e35bf', optional = true}
+frame-support = {default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = '2a7a734c373d0b28c6c658667effd3fb8c9e35bf'}
+frame-system = {default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = '2a7a734c373d0b28c6c658667effd3fb8c9e35bf'}
 
 [dev-dependencies]
 serde = '1.0.126'
-sp-runtime = {default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = '55cd07a7e22c26932f7bd16b87ea5a7569e38eb4'}
-sp-core = {default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = '55cd07a7e22c26932f7bd16b87ea5a7569e38eb4'}
-sp-io = {default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = '55cd07a7e22c26932f7bd16b87ea5a7569e38eb4'}
+sp-runtime = {default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = '2a7a734c373d0b28c6c658667effd3fb8c9e35bf'}
+sp-core = {default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = '2a7a734c373d0b28c6c658667effd3fb8c9e35bf'}
+sp-io = {default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = '2a7a734c373d0b28c6c658667effd3fb8c9e35bf'}
 
 [features]
 default = ['std']

--- a/src/brackets.rs
+++ b/src/brackets.rs
@@ -103,7 +103,10 @@ where
 			index_vector.push((start, end));
 		}
 
-		BracketsTransient { index_vector, _phantom: PhantomData }
+		BracketsTransient {
+			index_vector,
+			_phantom: PhantomData,
+		}
 	}
 }
 
@@ -151,7 +154,7 @@ where
 		// check all brackets if key is queued
 		for i in 0..self.index_vector.len() {
 			if N::contains_key(i as Bracket, &item_key) {
-				return false
+				return false;
 			}
 		}
 
@@ -178,7 +181,7 @@ where
 	/// Will remove the item, but will not update the bounds in storage.
 	fn pop(&mut self, bracket: Bracket) -> Option<Item> {
 		if self.is_empty(bracket) {
-			return None
+			return None;
 		}
 
 		let (mut v_start, v_end) = self.index_vector[bracket as usize];
@@ -205,9 +208,9 @@ where
 		let (v_start, v_end) = self.index_vector[bracket as usize];
 
 		if v_start <= v_end {
-			return v_end - v_start
+			return v_end - v_start;
 		} else {
-			return (BufferIndex::MAX - v_start) + v_end
+			return (BufferIndex::MAX - v_start) + v_end;
 		}
 	}
 
@@ -216,7 +219,7 @@ where
 		// check all brackets if key is queued
 		for i in 0..self.index_vector.len() {
 			if N::contains_key(i as Bracket, &item_key) {
-				return true
+				return true;
 			}
 		}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,7 +164,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		let player = PlayerStruct { account };
 		// duplicate check if we can add key to the queue
 		if !queue.push(bracket, player.account.clone(), player.clone()) {
-			return false
+			return false;
 		}
 
 		Self::deposit_event(Event::Queued(player));
@@ -195,23 +195,23 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		for i in 0..Self::brackets_count() {
 			// skip if bracket is empty
 			if queue.size(i) == 0 {
-				continue
+				continue;
 			}
 			// iterate for each slot occupied and fill, till player match size reached
 			for _j in 0..queue.size(i) {
 				if brackets.len() == max_players as usize {
-					break
+					break;
 				}
 				brackets.push(i);
 			}
 			// leave if brackets is filled with brackets
 			if brackets.len() == max_players as usize {
-				break
+				break;
 			}
 		}
 		// vec not filled with enough brackets leave
 		if brackets.len() < max_players as usize {
-			return result
+			return result;
 		}
 
 		// pop from the harvested brackets players

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ pub enum MatchingType {
 	Mix,
 }
 
-#[derive(Encode, Decode, Default, Clone, PartialEq, Eq, Debug, TypeInfo, MaxEncodedLen)]
+#[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, TypeInfo, MaxEncodedLen)]
 pub struct PlayerStruct<AccountId> {
 	account: AccountId,
 }
@@ -100,7 +100,7 @@ pub mod pallet {
 		Blake2_128Concat,
 		BufferIndex,
 		T::AccountId,
-		ValueQuery,
+		OptionQuery,
 	>;
 
 	#[pallet::storage]
@@ -112,7 +112,7 @@ pub mod pallet {
 		Blake2_128Concat,
 		T::AccountId,
 		PlayerStruct<T::AccountId>,
-		ValueQuery,
+		OptionQuery,
 	>;
 
 	// Pallets use events to inform users when important changes are made.

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -66,5 +66,8 @@ impl pallet_matchmaker::Config for Test {
 
 // Build genesis storage according to the mock runtime.
 pub fn new_test_ext() -> sp_io::TestExternalities {
-	system::GenesisConfig::default().build_storage::<Test>().unwrap().into()
+	system::GenesisConfig::default()
+		.build_storage::<Test>()
+		.unwrap()
+		.into()
 }

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -51,7 +51,7 @@ impl system::Config for Test {
 	type SystemWeightInfo = ();
 	type SS58Prefix = SS58Prefix;
 	type OnSetCode = ();
-	type MaxConsumers = ();
+	type MaxConsumers = frame_support::traits::ConstU32<1>;
 }
 
 parameter_types! {

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -51,6 +51,7 @@ impl system::Config for Test {
 	type SystemWeightInfo = ();
 	type SS58Prefix = SS58Prefix;
 	type OnSetCode = ();
+	type MaxConsumers = ();
 }
 
 parameter_types! {


### PR DESCRIPTION
Following what's mentioned in https://github.com/paritytech/substrate/pull/10403,
- `Default` is removed for `PlayerStruct` (to avoid deriving default values for `T::AccountId`) and
- `OptionQuery` is used for `BracketIndexKeyMap` and `BracketKeyValueMap` storage items

---

Changes (in the order of commits):
- https://github.com/ajuna-network/pallet-ajuna-matchmaker/commit/3b64a3ece2b8451f46c5bb4b46cb0a7a62066886: run `cargo fmt`
- https://github.com/ajuna-network/pallet-ajuna-matchmaker/commit/293c85002e83af6aaddb6b28ea306b64a17192c4: peg / freeze upstream dependencies at a revision
  - specifying `version` seems a little bit meaningless for us since we're pointed directly to the latest upstream `master`
  - instead, using `rev` to peg at a commit hash
  - chosen this commit, https://github.com/paritytech/substrate/commit/3dc984280b4380179fa83a3895aff84048dfe146, as it was the highest commit without breaking changes
- https://github.com/ajuna-network/pallet-ajuna-matchmaker/commit/c18cbba0cb546efa84c80052d2750a8f26919e6d: point to the commit of the breaking changes, https://github.com/paritytech/substrate/commit/55cd07a7e22c26932f7bd16b87ea5a7569e38eb4, and fix any errors
  - removed deriving `Default` for `PlayerStruct` as mentioned in https://github.com/paritytech/substrate/pull/10403
  - use `OptionQuery` for the storage items dealing with `T::AccountId`
  - add the recently introduced `MaxConsumers` for mock (as empty for now)
  - small refactor for `fn pop()` since the storage items now return `Option`
- https://github.com/ajuna-network/pallet-ajuna-matchmaker/pull/18/commits/18d608bdc05eb4c6ac30fd81824e22231b80b653: point to the latest `master`
---
Closes #17.